### PR TITLE
Add Node test suite for showResults

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -18,14 +18,17 @@ const articles = [
   ];
   
   // Handle form submit
+if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', function () {
     const form = document.querySelector('.search-form');
+    if (!form) return;
     form.addEventListener('submit', function (e) {
       e.preventDefault();
       const query = this.search.value.trim();
       showResults(query);
     });
   });
+}
   
   function showResults(query) {
     const resultsDiv = document.getElementById('searchResults');
@@ -104,7 +107,13 @@ const articles = [
   
   
 
+if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', function () {
     showHomepageArticles();
   });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { showResults, articles };
+}
   

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tomarnet",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/showResults.test.js
+++ b/tests/showResults.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('assert');
+const { showResults } = require('../js/script');
+
+function createMockDocument() {
+  const elements = {};
+  return {
+    createElement: () => ({
+      className: '',
+      innerHTML: '',
+      children: [],
+      appendChild(child) {
+        this.children.push(child);
+      }
+    }),
+    getElementById: id => {
+      if (!elements[id]) {
+        elements[id] = {
+          innerHTML: '',
+          children: [],
+          appendChild(child) {
+            this.children.push(child);
+            this.innerHTML += child.innerHTML;
+          }
+        };
+      }
+      return elements[id];
+    }
+  };
+}
+
+test('filters articles by query', () => {
+  const mockDocument = createMockDocument();
+  global.document = mockDocument;
+  showResults('قوة');
+  const div = mockDocument.getElementById('searchResults');
+  assert.strictEqual(div.children.length, 1);
+  assert.ok(div.innerHTML.includes('قوة المعرفة'));
+  delete global.document;
+});
+
+test('returns no results when no match', () => {
+  const mockDocument = createMockDocument();
+  global.document = mockDocument;
+  showResults('لايوجد');
+  const div = mockDocument.getElementById('searchResults');
+  assert.strictEqual(div.innerHTML, '<p>لا توجد نتائج.</p>');
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- add Node-based test suite under `tests/`
- export `showResults` for Node testing and guard DOM access
- provide `node --test` npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459c6e974c8323abb72f0e5762439b